### PR TITLE
fix: correcao botao home e termos

### DIFF
--- a/src/components/BottomBar.tsx
+++ b/src/components/BottomBar.tsx
@@ -119,7 +119,7 @@ export const BottomBar = ({ selectedTab }: { selectedTab: Tab | null }) => {
                 href={item.href}
                 className={
                   item.name === selectedTab
-                    ? "rounded-xl border-2 border-[#84d8ff] bg-[#ddf4ff] px-2 py-1"
+                    ? "rounded-xl px-2 py-1"
                     : "px-2 py-1"
                 }
               >

--- a/src/components/LeftBar.tsx
+++ b/src/components/LeftBar.tsx
@@ -95,11 +95,10 @@ export const LeftBar = ({ selectedTab }: { selectedTab: Tab | null }) => {
               <li key={item.href} className="flex flex-1">
                 <Link
                   href={item.href}
-                  className={`flex grow items-center gap-3 rounded-xl px-2 py-1 text-sm font-bold uppercase ${
-                    item.name === selectedTab
-                      ? "border-2 border-[#84d8ff] bg-[#ddf4ff] text-blue-400"
+                  className={`flex grow items-center gap-3 rounded-xl px-2 py-1 text-sm font-bold uppercase ${item.name === selectedTab
+                      ? "text-[#9CA3AF]"
                       : "text-gray-400 hover:bg-gray-100"
-                  }`}
+                    }`}
                 >
                   {item.icon(isActive)}
                   <span className="sr-only lg:not-sr-only">{item.name}</span>

--- a/src/components/ProfileFormModal.tsx
+++ b/src/components/ProfileFormModal.tsx
@@ -273,7 +273,7 @@ const ProfileFormModal: React.FC<ProfileFormModalProps> = ({ isOpen, onClose, us
             <br />
             Para participar do programa, é necessário concordar com os termos de uso e a política de privacidade. Ao aceitar, você declara estar ciente e de acordo com as regras e condições estabelecidas. Saiba mais em nossa{" "}
             <a
-              href="https://docs.google.com/document/d/1t-ng5n29UiPdDgK8mcXtCWDxidn3gNCWK7Xg9_T6Qps/edit?tab=t.0"
+              href="https://poli.digital/policoins/termos-e-condicoes/"
               className="text-blue-600 underline"
               target="_blank"
               rel="noopener noreferrer"

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -118,7 +118,7 @@ const Learn: NextPage = () => {
 
   return (
     <>
-      <LeftBar selectedTab="Learn" />
+      <LeftBar selectedTab="Home" />
 
       {/* Overlay de carregamento */}
       {isLoading && (
@@ -242,7 +242,7 @@ const Learn: NextPage = () => {
 
       {/* Footer with Terms of Use Message and Profile Form */}
       <div className="relative">
-        <BottomBar selectedTab="Learn" />
+        <BottomBar selectedTab="Home" />
         <ProfileFormModal
           isOpen={showTerms}
           onClose={handleAcceptTerms}


### PR DESCRIPTION
This pull request focuses on UI updates and content adjustments to improve the user experience and ensure accurate information. The most important changes include simplifying the styling for selected tabs, updating the terms of use link, and correcting selected tab references in the `Home` page.

### UI Styling Updates:
* [`src/components/BottomBar.tsx`](diffhunk://#diff-09516901b9f38555016f1b32930c4b3066475de12aa81f3b22d36a1c2087e9d7L122-R122): Removed the border and background styling for the selected tab to simplify the appearance.
* [`src/components/LeftBar.tsx`](diffhunk://#diff-8571698cba98d1d62ab5ba0244bdf624fc34db129389f1b0da9f48a579efb24aL98-R99): Updated the selected tab styling to use a neutral gray text color instead of a blue border and background.

### Content Updates:
* [`src/components/ProfileFormModal.tsx`](diffhunk://#diff-24063a46b36f4d3ab7f7dbe6510e09fda8b34969dba61c63c80a5250458599c6L276-R276): Updated the terms of use link to point to the correct URL (`https://poli.digital/policoins/termos-e-condicoes/`).

### Bug Fixes:
* [`src/pages/home.tsx`](diffhunk://#diff-7c8d28ff1de800f1a1770a7f9bf600faa23af4ef36b2b27e7af3cc0b4b473ff4L121-R121): Corrected the `selectedTab` value for both `LeftBar` and `BottomBar` components from `"Learn"` to `"Home"`. [[1]](diffhunk://#diff-7c8d28ff1de800f1a1770a7f9bf600faa23af4ef36b2b27e7af3cc0b4b473ff4L121-R121) [[2]](diffhunk://#diff-7c8d28ff1de800f1a1770a7f9bf600faa23af4ef36b2b27e7af3cc0b4b473ff4L245-R245)